### PR TITLE
fix: gracefully handle non-git directories in UserPromptSubmit hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ bumper-lanes-plugin/bin/.build-version
 .claude/*
 !.claude/settings.local.json
 !.claude/commands/
+.idea/

--- a/bumper-lanes-plugin/tools/bumper-lanes/internal/hooks/prompt_handler.go
+++ b/bumper-lanes-plugin/tools/bumper-lanes/internal/hooks/prompt_handler.go
@@ -47,6 +47,11 @@ func HandlePrompt(input *HookInput) int {
 		return 0
 	}
 
+	// Early exit if not in a git repository - bumper-lanes commands require git
+	if !IsGitRepo() {
+		return 0 // Pass through - not in a git repo
+	}
+
 	sessionID := input.SessionID
 
 	// Simple commands (no args) - use string matching for performance

--- a/bumper-lanes-plugin/tools/bumper-lanes/internal/hooks/prompt_handler_test.go
+++ b/bumper-lanes-plugin/tools/bumper-lanes/internal/hooks/prompt_handler_test.go
@@ -1,6 +1,7 @@
 package hooks
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,68 +29,145 @@ func TestHasStatusLineConfigured(t *testing.T) {
 	origHome := os.Getenv("HOME")
 	defer os.Setenv("HOME", origHome)
 
-	t.Run("returns false when no settings file", func(t *testing.T) {
-		tmpHome := t.TempDir()
-		os.Setenv("HOME", tmpHome)
+	t.Run(
+		"returns false when no settings file", func(t *testing.T) {
+			tmpHome := t.TempDir()
+			os.Setenv("HOME", tmpHome)
 
-		if hasStatusLineConfigured() {
-			t.Error("hasStatusLineConfigured() = true, want false when no settings")
-		}
-	})
+			if hasStatusLineConfigured() {
+				t.Error("hasStatusLineConfigured() = true, want false when no settings")
+			}
+		},
+	)
 
-	t.Run("returns false when statusLine not configured", func(t *testing.T) {
-		tmpHome := t.TempDir()
-		os.Setenv("HOME", tmpHome)
+	t.Run(
+		"returns false when statusLine not configured", func(t *testing.T) {
+			tmpHome := t.TempDir()
+			os.Setenv("HOME", tmpHome)
 
-		claudeDir := filepath.Join(tmpHome, ".claude")
-		os.MkdirAll(claudeDir, 0755)
-		os.WriteFile(filepath.Join(claudeDir, "settings.json"),
-			[]byte(`{"theme": "dark"}`), 0644)
+			claudeDir := filepath.Join(tmpHome, ".claude")
+			os.MkdirAll(claudeDir, 0755)
+			os.WriteFile(
+				filepath.Join(claudeDir, "settings.json"),
+				[]byte(`{"theme": "dark"}`), 0644,
+			)
 
-		if hasStatusLineConfigured() {
-			t.Error("hasStatusLineConfigured() = true, want false when statusLine absent")
-		}
-	})
+			if hasStatusLineConfigured() {
+				t.Error("hasStatusLineConfigured() = true, want false when statusLine absent")
+			}
+		},
+	)
 
-	t.Run("returns false when statusLine has no command", func(t *testing.T) {
-		tmpHome := t.TempDir()
-		os.Setenv("HOME", tmpHome)
+	t.Run(
+		"returns false when statusLine has no command", func(t *testing.T) {
+			tmpHome := t.TempDir()
+			os.Setenv("HOME", tmpHome)
 
-		claudeDir := filepath.Join(tmpHome, ".claude")
-		os.MkdirAll(claudeDir, 0755)
-		os.WriteFile(filepath.Join(claudeDir, "settings.json"),
-			[]byte(`{"statusLine": {"type": "command"}}`), 0644)
+			claudeDir := filepath.Join(tmpHome, ".claude")
+			os.MkdirAll(claudeDir, 0755)
+			os.WriteFile(
+				filepath.Join(claudeDir, "settings.json"),
+				[]byte(`{"statusLine": {"type": "command"}}`), 0644,
+			)
 
-		if hasStatusLineConfigured() {
-			t.Error("hasStatusLineConfigured() = true, want false when command missing")
-		}
-	})
+			if hasStatusLineConfigured() {
+				t.Error("hasStatusLineConfigured() = true, want false when command missing")
+			}
+		},
+	)
 
-	t.Run("returns false when command is empty string", func(t *testing.T) {
-		tmpHome := t.TempDir()
-		os.Setenv("HOME", tmpHome)
+	t.Run(
+		"returns false when command is empty string", func(t *testing.T) {
+			tmpHome := t.TempDir()
+			os.Setenv("HOME", tmpHome)
 
-		claudeDir := filepath.Join(tmpHome, ".claude")
-		os.MkdirAll(claudeDir, 0755)
-		os.WriteFile(filepath.Join(claudeDir, "settings.json"),
-			[]byte(`{"statusLine": {"command": ""}}`), 0644)
+			claudeDir := filepath.Join(tmpHome, ".claude")
+			os.MkdirAll(claudeDir, 0755)
+			os.WriteFile(
+				filepath.Join(claudeDir, "settings.json"),
+				[]byte(`{"statusLine": {"command": ""}}`), 0644,
+			)
 
-		if hasStatusLineConfigured() {
-			t.Error("hasStatusLineConfigured() = true, want false when command empty")
-		}
-	})
+			if hasStatusLineConfigured() {
+				t.Error("hasStatusLineConfigured() = true, want false when command empty")
+			}
+		},
+	)
 
-	t.Run("returns true when command is configured", func(t *testing.T) {
-		tmpHome := t.TempDir()
-		os.Setenv("HOME", tmpHome)
+	t.Run(
+		"returns true when command is configured", func(t *testing.T) {
+			tmpHome := t.TempDir()
+			os.Setenv("HOME", tmpHome)
 
-		claudeDir := filepath.Join(tmpHome, ".claude")
-		os.MkdirAll(claudeDir, 0755)
-		os.WriteFile(filepath.Join(claudeDir, "settings.json"),
-			[]byte(`{"statusLine": {"command": "/path/to/script.sh"}}`), 0644)
+			claudeDir := filepath.Join(tmpHome, ".claude")
+			os.MkdirAll(claudeDir, 0755)
+			os.WriteFile(
+				filepath.Join(claudeDir, "settings.json"),
+				[]byte(`{"statusLine": {"command": "/path/to/script.sh"}}`), 0644,
+			)
 
-		if !hasStatusLineConfigured() {
-			t.Error("hasStatusLineConfigured() = false, want true when command set")
-		}
-	})
+			if !hasStatusLineConfigured() {
+				t.Error("hasStatusLineConfigured() = false, want true when command set")
+			}
+		},
+	)
+}
+
+// TestHandlePromptNonGitRepo verifies graceful handling in non-git directories.
+func TestHandlePromptNonGitRepo(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(origDir)
+
+	// Create and change to a non-git temp directory
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Capture stdout to verify no blocking output
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	defer func() { os.Stdout = oldStdout }()
+
+	tests := []struct {
+		name   string
+		prompt string
+	}{
+		{"bumper-reset", "/bumper-reset"},
+		{"bumper-pause", "/bumper-pause"},
+		{"bumper-config", "/bumper-config"},
+		{"bumper-tree", "/bumper-tree"},
+		{"long form", "/claude-bumper-lanes:bumper-depth"},
+		{"non-bumper prompt", "hello world"},
+	}
+
+	for _, tc := range tests {
+		t.Run(
+			tc.name, func(t *testing.T) {
+				input := &HookInput{
+					SessionID:  "test-session-123",
+					UserPrompt: tc.prompt,
+				}
+
+				exitCode := HandlePrompt(input)
+
+				if exitCode != 0 {
+					t.Errorf("HandlePrompt(%q) = %d, want 0 (pass through)", tc.prompt, exitCode)
+				}
+			},
+		)
+	}
+
+	w.Close()
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	if output != "" {
+		t.Errorf("HandlePrompt in non-git repo produced output: %q, want empty (pass through)", output)
+	}
 }


### PR DESCRIPTION
Closes #4.

## Summary

- Add early `IsGitRepo()` check in `HandlePrompt` to gracefully skip processing when not in a git repository
- Add regression test to verify all bumper-lanes commands pass through in non-git directories
- Add `.idea/` to `.gitignore`

## Problem

When running Claude Code from a directory that is **not a git repository**, the `UserPromptSubmit` hook fails with a confusing error message:

```
UserPromptSubmit operation blocked by hook:
Error: No session state for 2fcc7320-021b-4043-a312-f92ec0481a46

Original prompt: /claude-bumper-lanes:bumper-depth
```

This happened because `HandlePrompt` attempted to process bumper-lanes commands and load session state (which requires git) before checking if we're in a git repository.

## Solution

Add an early `IsGitRepo()` check at the start of `HandlePrompt`, consistent with the existing pattern in `SessionStart` (line 34):

```go
// Early exit if not in a git repository - bumper-lanes commands require git
if !IsGitRepo() {
    return 0 // Pass through - not in a git repo
}
```

When not in a git repo, prompts are now passed through to Claude without any blocking or error messages.

## Test plan

- Added `TestHandlePromptNonGitRepo` regression test
- All existing tests pass (`go test ./...`)
- Manual verification: `/plugin` and other commands work in non-git directories